### PR TITLE
Changed README.md - Section "Within it you'll find"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The 'master' and the '7.02-7.31' branch never will be merged together!
 # Within it you'll find:
 * $ABAP_KOANS: this package contains everything and is the main entrypoint.
 * Navigate to the the global classes and go to the 'local Testclass section'. Run the ABAP Unit Tests with the shortcut CTRL+SHIFT+F10 and solve step by step the ongoing challenges.
-* Changes are **_only_** alowed in local Testclass section (e.g. lcl_koans_demo_constraint should stay like it is)
+* Changes are **_only_** allowed in local Testclass section (e.g. lcl_koans_demo_constraint should stay like it is)
 
 # Installation
 * Download this repository as a zip

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The 'master' and the '7.02-7.31' branch never will be merged together!
 # Within it you'll find:
 * $ABAP_KOANS: this package contains everything and is the main entrypoint.
 * Navigate to the the global classes and go to the 'local Testclass section'. Run the ABAP Unit Tests with the shortcut CTRL+SHIFT+F10 and solve step by step the ongoing challenges.
+* Changes are **_only_** alowed in local Testclass section (e.g. lcl_koans_demo_constraint should stay like it is)
 
 # Installation
 * Download this repository as a zip


### PR DESCRIPTION
Today one of our ABAPUnit starters has changed lcl_koans_demo_constraint implementation part to achieve a green bar for assert_that testmethod. As far as I understand this is not the goal of this exercise. Instead he should have changed only the local testclass. Therefore I suggest a clearer definition of where changes have to be done. @damir-majer Or am I missing something here?